### PR TITLE
Add check for no content type

### DIFF
--- a/src/services/async-http-client.ts
+++ b/src/services/async-http-client.ts
@@ -259,7 +259,7 @@ export class AsyncHttpClient implements Composable {
                 for (const h of headerNames) {
                     result.setHeader(h, resHeaders.get(h));
                 }
-                if (OPTIONS == method || HEAD == method) {
+                if (OPTIONS == method || HEAD == method || !resContentType) {
                     result.setHeader(CONTENT_LENGTH, "0");
                     result.setBody('');
                 } else if (fixedLenContent) {


### PR DESCRIPTION
In the case that an API returns no content and no content type as a result, don't try to read the content.